### PR TITLE
Add option to overwrite label default class.

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -307,12 +307,13 @@ module GovukElementsFormBuilder
 
     end
 
-    def set_label_classes! options
-      options ||= {}
+    def set_label_classes!(options = {})
       options[:label_options] ||= {}
-      options[:label_options].merge!(
+
+      return if options[:label_options].delete :overwrite_defaults!
+
+      options[:label_options].merge! \
         merge_attributes(options[:label_options], default: {class: 'govuk-label'})
-      )
     end
 
     def check_box_inputs attributes, options


### PR DESCRIPTION
We have a case in our app where we need to remove the standard
govuk-label class. The existing code always appends govuk-label to the
list of label classes, this commit adds a label option to skip this
behaviour.