### PR TITLE
Add option to skip adding a label

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -33,12 +33,15 @@ module GovukElementsFormBuilder
         content_tag :div, class: form_group_classes(attribute), id: form_group_id(attribute) do
           options = args.extract_options!
 
-          set_label_classes! options
           set_field_classes! options, attribute, [default_field_class]
 
-          label = label(attribute, options[:label_options])
-
-          add_hint :label, label, attribute
+          if options.delete :no_label
+            label = ''
+          else
+            set_label_classes! options
+            label = label(attribute, options[:label_options])
+            add_hint :label, label, attribute
+          end
 
           (label + super(attribute, options.except(:label, :label_options, :width))).html_safe
         end
@@ -309,8 +312,6 @@ module GovukElementsFormBuilder
 
     def set_label_classes!(options = {})
       options[:label_options] ||= {}
-
-      return if options[:label_options].delete :overwrite_defaults!
 
       options[:label_options].merge! \
         merge_attributes(options[:label_options], default: {class: 'govuk-label'})


### PR DESCRIPTION
Removes overwrite default option for labels as this approach is more
flexable