### PR TITLE
Adds hint tags before error message

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -478,13 +478,19 @@ module GovukElementsFormBuilder
     end
 
     def add_hint(tag, element, name)
-      hints = hint_text name
-      Array(hints).map { |hint| add_hint_span tag, element, hint }.join
-    end
+      hints = Array hint_text(name)
 
-    def add_hint_span(tag, element, hint)
-      hint_span = content_tag :span, hint, class: 'govuk-hint'
-      element.sub! "</#{tag}>", "#{hint_span}</#{tag}>".html_safe
+      hint_tags = hints.map do |hint|
+        content_tag :span, hint, class: 'govuk-hint'
+      end.join.html_safe
+
+      if element.include? 'class="govuk-error-message"'
+        element.sub! \
+          '<span class="govuk-error-message"',
+          %Q{#{hint_tags}<span class="govuk-error-message"}
+      else
+        element.sub! "</#{tag}>", "#{hint_tags}</#{tag}>".html_safe
+      end
     end
 
     def fieldset_text attribute


### PR DESCRIPTION
The design system specifies that error messages go after any hint tags.
https://design-system.service.gov.uk/components/error-message/
This commit fixes the form builder to match this requirement.

Rails' label method adds the error span to the label before we add in
the hints so we need to split on the span if it's present and add the
tags before that. If it's not present then we fall back to the old
behaviour.

It seems like the tag and element args to add_hint are always :label and
a label tag, but refactoring out these arguments is left as an exercise
to the reader.