### PR TITLE
Make field set heading setable

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -55,8 +55,9 @@ module GovukElementsFormBuilder
                   id: form_group_id(attribute) do
         content_tag :fieldset, fieldset_options(attribute, options) do
           content_tag(:div, {class: "govuk-radios govuk-radios__inline govuk-radios--conditional", "data-module" => "radios"}) do
+
             safe_join([
-                        fieldset_legend(attribute, options, heading: true),
+                        fieldset_legend(attribute, options, heading: options.fetch(:fieldset_heading, true)),
                         block_given? ? capture(self, &block) : radio_inputs(attribute, options)
                       ], "\n")
           end


### PR DESCRIPTION
Adds ability for caller to passing field set heading. This option was avaialbe but always set to true,
now defaults to true with optional override