### PR TITLE
Allow consumers to toggle fieldset_legend heading

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -390,6 +390,8 @@ module GovukElementsFormBuilder
     end
 
     def fieldset_legend(attribute, options, heading: false)
+      heading = options[:heading] || heading
+
       legend_classes = %w{govuk-fieldset__legend}
       legend_classes << 'govuk-fieldset__legend--m' if heading
       legend = content_tag('legend', class: legend_classes) do


### PR DESCRIPTION
Adds the ability to toggle the fieldset_legend heading as a form_builder user by passing in a heading option.