### PR TITLE
Use H2 inside fieldset legends instead of H1

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -400,7 +400,7 @@ module GovukElementsFormBuilder
 
         if heading
           tags << content_tag(
-            'h1',
+            'h2',
             fieldset_text(attribute),
             merge_attributes(options[:legend_options], default: {class: 'govuk-fieldset__heading'})
           )

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
 
       specify 'should be propagated down to the inner legend when provided' do
-        expect(subject).to have_tag("legend > h1.govuk-fieldset__heading.#{custom_class}", with: {lang: language})
+        expect(subject).to have_tag("legend > h2.govuk-fieldset__heading.#{custom_class}", with: {lang: language})
       end
 
     end
@@ -501,7 +501,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
     specify 'fieldset has the correct heading' do
       text = I18n.t('helpers.fieldset.person[waste_transport_attributes].waste_transport')
-      expect(subject).to have_tag('fieldset legend > h1.govuk-fieldset__heading', text)
+      expect(subject).to have_tag('fieldset legend > h2.govuk-fieldset__heading', text)
     end
 
     specify 'outputs checkboxes with labels' do


### PR DESCRIPTION
This should improve compatibility with screen readers and ensure a more logical hierarchy of headings within the page