### PR TITLE
Add autocompletion for date of birth fields

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -223,16 +223,16 @@ module GovukElementsFormBuilder
       super(value, {class: "govuk-button"}.merge(options))
     end
 
-    def date_field(attribute, options = {})
+    def date_field(attribute, options = {}, date_of_birth: false)
       content_tag :div, class: form_group_classes(attribute), id: form_group_id(attribute) do
         content_tag :fieldset, fieldset_options(attribute, options) do
 
           date_inputs = content_tag(:div, class: 'govuk-date-input') do |di|
 
             safe_join([
-              date_input_form_group(attribute, segment: :day),
-              date_input_form_group(attribute, segment: :month),
-              date_input_form_group(attribute, segment: :year, width: 4)
+              date_input_form_group(attribute, segment: :day, date_of_birth: date_of_birth),
+              date_input_form_group(attribute, segment: :month, date_of_birth: date_of_birth),
+              date_input_form_group(attribute, segment: :year, width: 4, date_of_birth: date_of_birth)
             ])
 
           end
@@ -263,8 +263,14 @@ module GovukElementsFormBuilder
     # Gov.UK Design System date inputs require a fieldset containing
     # separate number inputs for Day, Month and Year. Rails' handling
     # requires they are named with 3i, 2i and 1i prefix respectively
-    def date_input_form_group(attribute, segment: :day, width: 2)
+    def date_input_form_group(attribute, segment: :day, width: 2, date_of_birth:)
       segments = {day: '3i', month: '2i', year: '1i'}
+      autocomplete_segments = {
+        day: 'bday-day',
+        month: 'bday-month',
+        year: 'bday-year'
+      }
+
       content_tag(:div, class: %w{govuk-date-input__item}) do
 
         date_input_options = {
@@ -272,6 +278,10 @@ module GovukElementsFormBuilder
           type: 'number',
           pattern: '[0-9]*',
         }
+
+        if date_of_birth
+          date_input_options[:autocomplete] = autocomplete_segments[segment]
+        end
 
         attribute_segment = "#{attribute}(#{segments[segment]})"
         input_name = "#{attribute_prefix}[#{attribute_segment}]"

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -811,6 +811,40 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         end
       end
     end
+
+    context 'autocompletion' do
+      subject {builder.date_field(:created_at, date_of_birth: true)}
+
+      specify "day should have autocomplete value of 'bday-day'" do
+        expect(subject).to have_tag(
+          'input',
+          with: {
+            id: 'person_created_at_3i',
+            autocomplete: 'bday-day'
+          }
+        )
+      end
+
+      specify "month should have autocomplete value of 'bday-month'" do
+        expect(subject).to have_tag(
+          'input',
+          with: {
+            id: 'person_created_at_2i',
+            autocomplete: 'bday-month'
+          }
+        )
+      end
+
+      specify "year should have autocomplete value of 'bday-year'" do
+        expect(subject).to have_tag(
+          'input',
+          with: {
+            id: 'person_created_at_1i',
+            autocomplete: 'bday-year'
+          }
+        )
+      end
+    end
   end
 
   describe '#submit' do


### PR DESCRIPTION
When enabled the appropriate autocomplete attributes are added to the
date inputs. Nothing is added when disabled