### PR TITLE
Support after hint markup for collection select

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -114,7 +114,7 @@ module GovukElementsFormBuilder
       end
     end
 
-    def collection_select(method, collection, value_method, text_method, options = {}, *args)
+    def collection_select(method, collection, value_method, text_method, options = {}, *args, &block)
       content_tag :div, class: form_group_classes(method), id: form_group_id(method) do
 
         html_options = args.extract_options!
@@ -125,7 +125,11 @@ module GovukElementsFormBuilder
         label = label(method, { class: "govuk-label" }.merge(label_options))
         add_hint :label, label, method
 
-        (label + super(method, collection, value_method, text_method, options, html_options)).html_safe
+        block ||= proc { '' }
+
+        after_hint_markup = capture(self, &block)
+
+        (label + after_hint_markup + super(method, collection, value_method, text_method, options, html_options)).html_safe
       end
     end
 


### PR DESCRIPTION
Add the ability to pass in a block of html to be displayed after any
hint text / label