### PR TITLE
Add setting label text explicitly

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -35,8 +35,9 @@ module GovukElementsFormBuilder
 
           set_label_classes! options
           set_field_classes! options, attribute, [default_field_class]
-
-          label = label(attribute, options[:label_options])
+          
+          label_text = options.dig(:label_options, :text)
+          label = label(attribute, label_text, options[:label_options].except(:text))
 
           add_hint :label, label, attribute
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           expect(subject).to have_tag("label", with: label_options)
         end
       end
+      
+      context 'custom label text' do
+        let(:label_options) {{text: 'Custom label'}}
+        subject { builder.send(method, :name, label_options: label_options) }
+        
+        specify 'shows custom label text' do
+          expect(subject).to have_tag("label", text: 'Custom label')
+        end
+      end
 
     end
 


### PR DESCRIPTION
If an attribute name on a model is dynamic, than it may not possible to retrieve the appropriate label  from the attribute name utilising translations.

Allow manually setting the `:text` of the label in the `:label_options` attribute on the various `*_field` helper methods